### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Branch out the XP 7 maintenance line at the post-release SNAPSHOT commit and configure release-branch CI for both `master` and `1.x`.

## Changes
- `.github/workflows/enonic-gradle.yml`: declare `releaseBranch:` listing both `master` and `1.x` so pushes to either branch are recognized as release-branch builds by `enonic/release-tools/build-and-publish`.

## Notes
- `gradle.properties` is already at `version=2.0.0-SNAPSHOT` (set by the XP 8 upgrade), so no version bump is needed on master.
- Maintenance branch `1.x` was created at `987d43e` (post-`v1.0.0-B2` SNAPSHOT commit, `version = 1.0.0-B3-SNAPSHOT`).
- Companion PR will be opened against `1.x` to add the same `releaseBranch:` block on that branch's workflow file.