### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -1,122 +1,29 @@
 name: Gradle Build
 
-on: [push]
+on: [ push ]
 
 jobs:
   build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
+  release:
     runs-on: ubuntu-latest
 
-    needs: release_notes
+    needs: build
+    if: needs.build.outputs.release == 'true'
 
     steps:
-      - uses: actions/checkout@v2.3.4
-
-      - uses: actions/setup-java@v1
+      - uses: enonic/release-tools/release@master
         with:
-          java-version: 11
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - run: ./gradlew build
-
-      - uses: codecov/codecov-action@v1.2.1
-
-      ### PUBLISHING STEPS ###
-
-      - name: Read version property
-        id: read_version
-        uses: christian-draeger/read-properties@1.0.1
-        with:
-          path: './gradle.properties'
-          property: 'version'
-
-      - name: Read projectName property
-        id: read_project_name
-        uses: christian-draeger/read-properties@1.0.1
-        with:
-          path: './gradle.properties'
-          property: 'projectName'
-
-      - name: Fail on bad config
-        if: steps.read_version.outputs.value == '' || steps.read_project_name.outputs.value == ''
-        run: exit 1
-
-      - name: Get publishing variables
-        id: get_publish_vars
-        run: |
-          PUBLISH=${{ github.ref == 'refs/heads/master' }}
-
-          echo ::set-output name=publish::$PUBLISH
-
-          if ${{ contains(steps.read_version.outputs.value, '-SNAPSHOT') }};
-          then
-            echo "::set-output name=release::false"
-            echo "::set-output name=repo::snapshot"
-          else
-            echo "::set-output name=release::true"
-            echo "::set-output name=repo::public"
-          fi
-
-      - name: Publish
-        if: steps.get_publish_vars.outputs.publish == 'true'
-        run: ./gradlew publish -PrepoKey=${{ steps.get_publish_vars.outputs.repo }} -PrepoUser=${{ secrets.ARTIFACTORY_USERNAME }} -PrepoPassword=${{ secrets.ARTIFACTORY_PASSWORD }}
-
-      - name: Download changelog
-        if: steps.get_publish_vars.outputs.release == 'true'
-        uses: actions/download-artifact@v2
-        with:
-          name: changelog
-
-      - name: Create Release
-        if: steps.get_publish_vars.outputs.release == 'true'
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ steps.read_version.outputs.value }}
-          body_path: changelog.md
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        if: "steps.create_release.outputs.upload_url != ''"
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: "build/libs/${{ steps.read_project_name.outputs.value }}-${{ steps.read_version.outputs.value }}.jar"
-          asset_name: "${{ steps.read_project_name.outputs.value }}-${{ steps.read_version.outputs.value }}.jar"
-          asset_content_type: application/java-archive
-
-  release_notes:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
-
-      - name: Get previous release tag
-        id: get_previous_release_tag
-        run: |
-          PREVIOUS_RELEASE_TAG=$(git tag --sort=-version:refname --merged | grep -E '^v([[:digit:]]+\.){2}[[:digit:]]+$' | head -1)
-          echo ::set-output name=previous_release_tag::$PREVIOUS_RELEASE_TAG
-
-      - name: Generate Release Notes
-        uses: enonic/release-tools/generate-changelog@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ZENHUB_TOKEN: ${{ secrets.ZENHUB_TOKEN }}
-          PREVIOS_RELEASE_TAG: ${{ steps.get_previous_release_tag.outputs.previous_release_tag }}
-          OUTPUT_FILE: changelog.md
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: changelog
-          path: changelog.md
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Configure release-branch CI on the new `1.x` maintenance branch so pushes here are recognized as release-branch builds by `enonic/release-tools/build-and-publish`.

## Changes
- `.github/workflows/enonic-gradle.yml`: replaced the old multi-job structure (which predates `releaseBranch:` support) with the modern `build-and-publish` + `release` jobs and a `releaseBranch:` block listing both `master` and `1.x`. This mirrors the workflow file on `master`.

## Notes
- `gradle.properties` is intentionally left at `1.0.0-B3-SNAPSHOT` (the post-`v1.0.0-B2` SNAPSHOT version on this branch).
- Companion master PR: enonic/lib-galimatias#109.