### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation xplibs.content
     implementation xplibs.portal
 
-    implementation "io.mola.galimatias:galimatias:0.2.1"
+    implementation libs.galimatias
 
     testImplementation "com.enonic.xp:testing:${xpVersion}"
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+galimatias = "0.2.1"
+
+[libraries]
+galimatias = { module = "io.mola.galimatias:galimatias", version.ref = "galimatias" }


### PR DESCRIPTION
## Summary

Migrates `lib-galimatias` from inline-versioned dependencies to a Gradle TOML version catalog (`gradle/libs.versions.toml`), aligning this repo with neighbouring repos like `app-features` and `lib-explorer` that already use the catalog format. Pin-for-pin; no version bumps.

## Conventions adopted

- Alphabetical sort within `[versions]` and `[libraries]`.
- Hyphen-separated, lowercase keys.
- `xpVersion` left in `gradle.properties` — the rest of the toolchain expects it there.
- `xplibs.*` accessors untouched (they come from the XP gradle plugin, not a per-repo catalog).
- No `[plugins]` block — matches the convention in `app-features` / `lib-explorer`, which keep `com.enonic.defaults` and `com.github.node-gradle.node` versions inline in `build.gradle`.
- Unversioned junit testRuntime entries (`junit-jupiter-engine`, `junit-platform-launcher`) stay inline — they're transitively resolved via `com.enonic.xp:testing` and have no explicit version to catalog.

## New catalog

```toml
[versions]
galimatias = "0.2.1"

[libraries]
galimatias = { module = "io.mola.galimatias:galimatias", version.ref = "galimatias" }
```

## Verification

- `./gradlew build --refresh-dependencies` — green, tests pass.
- `./gradlew dependencies --configuration runtimeClasspath` — byte-identical to pre-migration output.

## Test plan

- [x] Build green locally
- [x] runtimeClasspath dependency tree unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)